### PR TITLE
Fix broken image URL

### DIFF
--- a/html/404.html
+++ b/html/404.html
@@ -5,7 +5,7 @@
     <title>Page not found | Enrise</title>
     <style type="text/css">
         html, body { height: 100%; margin: 0; padding: 0 }
-        body { background: #f2a900 url('assets/enrise-logo.png') center center no-repeat; }
+        body { background: #f2a900 url('/assets/enrise-logo.png') center center no-repeat; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
# What

When a route is containing sub paths `/like/this/path/`, the enrise logo wasn't showing. This fixes that.