### PR TITLE
Update Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.16
 
 RUN apk -U add dumb-init nginx \
     && rm -rf /etc/nginx/conf.d


### PR DESCRIPTION
Alpine was very old, still on v3.10. It now runs on v3.16 which is support for a few years to come.